### PR TITLE
Fix for running on Windows

### DIFF
--- a/lib/git_pr/merge.rb
+++ b/lib/git_pr/merge.rb
@@ -1,5 +1,3 @@
-require 'shellwords'
-
 module GitPr
 
   def self.ensure_remotes_for_pull_request git, pull
@@ -169,8 +167,7 @@ Merge #{pull.summary}
 
 #{pull.body}
 EOS
-    GitPr.run_command "git merge --no-ff #{rebase_branch} -m #{Shellwords.escape commit_message}"
-
+    GitPr.run_command "git merge --no-ff #{rebase_branch} -m \"#{commit_message}\""
     # Print a log of the merge with branch structure visible. Jump through hoops to
     # get the right branch to start the log revision range with. If origin/develop
     # is a merge commit, we need the right parent of the merge.

--- a/lib/git_pr/merge.rb
+++ b/lib/git_pr/merge.rb
@@ -176,15 +176,19 @@ Merge #{pull.summary}
 
 #{pull.body}
 EOS
-    cmd = "git merge --no-ff #{rebase_branch} -m #{Shellwords.escape commit_message}"
+    escaped_commit_message = Shellwords.escape commit_message
+
+    # Detect if running on Windows
+    # https://stackoverflow.com/a/4871457
     is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
     if is_windows
       # We're running on Windows, so `Shellwords.escape commit_message` may produce
       # a string that DOS-based shells will have trouble interpretting.
       # Instead we escape for DOS shell rather than Bourne again (bash) shell
-      cmd = "git merge --no-ff #{rebase_branch} -m #{GitPr.dos_escape commit_message}"
+      escaped_commit_message = GitPr.dos_escape commit_message
     end
-    GitPr.run_command cmd
+
+    GitPr.run_command "git merge --no-ff #{rebase_branch} -m #{escaped_commit_message}"
 
     # Print a log of the merge with branch structure visible. Jump through hoops to
     # get the right branch to start the log revision range with. If origin/develop


### PR DESCRIPTION
Hi Brian, hope all is well.  I recently changed jobs where I have to work on a Windows machine and am trying to get folks using your script here so everyone can see the benefits of a clean git history.  However, I ran into trouble with `Shellwords.escape` on a Windows shell - it seems that this outputs a format that even a bash shell on Windows has trouble with 😦 

The fix in this PR is to detect when we're running on Windows, and instead of using `Shellwords.escape`, use a function called `dos_escape` (found online in a Ruby facet) to escape properly for the DOS shell. 

Thanks for considering!